### PR TITLE
Fix prometheus query logging/ticker bugs and allow passing nomad ca cart from env var

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,7 @@ WORKDIR /go/src/github.com/trivago/scalad
 RUN go get
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o /scalad
 
-FROM scratch 
+FROM alpine:latest
 
-# Copy root filesystem
-COPY rootfs /
 COPY --from=build-env /scalad /
 ENTRYPOINT ["/scalad"]

--- a/main.go
+++ b/main.go
@@ -28,6 +28,7 @@ var (
 	port                = os.Getenv("PORT")
 	nomadHost           = os.Getenv("NOMAD_HOST")
 	region              = os.Getenv("NOMAD_REGION")
+	nomadCaCert         = os.Getenv("NOMAD_CACERT")
 	vaultToken          = os.Getenv("VAULT_TOKEN")
 	useSlack            = os.Getenv("USE_SLACK")
 	username            = os.Getenv("HTTP_USER")
@@ -365,7 +366,7 @@ func readMeta(t map[string]string) *structs.Meta {
 func getJobs() (map[string]*nomad.Job, error) {
 	jobMap := make(map[string]*nomad.Job)
 
-	nomadClient, err := api.NewClient(&api.Config{Address: nomadHost, TLSConfig: &api.TLSConfig{}})
+	nomadClient, err := api.NewClient(&api.Config{Address: nomadHost, TLSConfig: &api.TLSConfig{CACert: nomadCaCert}})
 	if err != nil {
 		log.Error("Error creating nomad client with err: ", err)
 	}
@@ -428,6 +429,7 @@ func main() {
 	log.Info("Port:            ", port)
 	log.Info("Nomad Host:      ", nomadHost)
 	log.Info("Nomad Region:    ", region)
+	log.Info("Nomad CA Cert:   ", nomadCaCert)
 	if len(vaultToken) != 0 {
 		log.Info("Vault Token:     ", "************")
 	} else {
@@ -471,7 +473,7 @@ func GetJob(jobID string, region string) (nomad.Job, error) {
 
 	var nomadJob nomad.Job
 
-	client, err := api.NewClient(&api.Config{Address: nomadHost, TLSConfig: &api.TLSConfig{}})
+	client, err := api.NewClient(&api.Config{Address: nomadHost, TLSConfig: &api.TLSConfig{CACert: nomadCaCert}})
 	if err != nil {
 		log.Error("Unable to create Nomad client with err: ", err)
 		return nomadJob, err
@@ -494,7 +496,7 @@ func GetJob(jobID string, region string) (nomad.Job, error) {
 func executeJob(nomadJob nomad.Job) (ok bool, err error) {
 	*nomadJob.VaultToken = vaultToken
 
-	nomadClient, err := api.NewClient(&api.Config{Address: nomadHost, TLSConfig: &api.TLSConfig{}})
+	nomadClient, err := api.NewClient(&api.Config{Address: nomadHost, TLSConfig: &api.TLSConfig{CACert: nomadCaCert}})
 	if err != nil {
 		log.Error("Unable to create Nomad client with err: ", err)
 		return false, err

--- a/main.go
+++ b/main.go
@@ -226,12 +226,9 @@ func prometheusQueries(jobMetaMap map[string]*structs.Meta) {
 		job.MaxQuery = strings.Replace(job.MaxQuery, "\\", "", -1)
 		job.MinQuery = strings.Replace(job.MinQuery, "\\", "", -1)
 
-		maxQuery := metricsEndpoint + job.MaxQuery
-		minQuery := metricsEndpoint + job.MinQuery
-
 		log.Debug("Job: ", id)
-		log.Debug("MaxQuery query: ", maxQuery)
-		maxResult, err := queryPrometheus(maxQuery, job.MaxQuery)
+		log.Debug("MaxQuery: ", job.MaxQuery)
+		maxResult, err := queryPrometheus(job.MaxQuery)
 		if err != nil {
 			log.Error("Unable to get max result from prometheus with err: ", err, " for job: ", id)
 			removeFromFiringMap(id)
@@ -244,8 +241,8 @@ func prometheusQueries(jobMetaMap map[string]*structs.Meta) {
 			continue
 		}
 
-		log.Debug("MinQuery query: ", minQuery)
-		minResult, err := queryPrometheus(minQuery, job.MinQuery)
+		log.Debug("MinQuery: ", job.MinQuery)
+		minResult, err := queryPrometheus(job.MinQuery)
 		if err != nil {
 			log.Error("Unable to get min result from prometheus with err: ", err, " for job: ", id)
 			removeFromFiringMap(id)
@@ -262,14 +259,17 @@ func prometheusQueries(jobMetaMap map[string]*structs.Meta) {
 	jobMetaMapMutex.Unlock()
 }
 
-func queryPrometheus(query string, promQuery string) (bool, error) {
+func queryPrometheus(promQuery string) (bool, error) {
 	var result structs.Prometheus
 
 	client := &http.Client{
 		Timeout: (time.Second * 10),
 	}
 
-	u, err := url.Parse(fmt.Sprintf("%s%s", metricsEndpoint, url.QueryEscape(promQuery)))
+	query_url := fmt.Sprintf("%s%s", metricsEndpoint, url.QueryEscape(promQuery))
+	log.Debug("Query URL: ", query_url)
+
+	u, err := url.Parse(query_url)
 	req, err := http.NewRequest("GET", u.String(), nil)
 	if err != nil {
 		log.Error("Error creating new request with err: ", err)

--- a/tickers.go
+++ b/tickers.go
@@ -18,7 +18,7 @@ func fireMapTicker() {
 }
 
 func scalerTicker() {
-	ticker := time.NewTicker(time.Minute * time.Duration(scalerTickerEnvInt))
+	ticker := time.NewTicker(time.Second * time.Duration(scalerTickerEnvInt))
 
 	var err error
 	go func() {


### PR DESCRIPTION
This is needed for us to run scalad in our nomad cluster.
Also changing the base image to alpine so we can exec into container and do some debugging.

Resolves:
https://github.com/zumper/zumper_code/issues/25084